### PR TITLE
Revert "build(deps): bump @babel/runtime from 7.26.9 to 7.26.10 in /storefront"

### DIFF
--- a/storefront/package-lock.json
+++ b/storefront/package-lock.json
@@ -41,10 +41,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
-      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
-      "license": "MIT",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
+      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },


### PR DESCRIPTION
## 🚀 Pull Request Template
## 📄 Description

This PR includes the following changes:
- Merge 26644c1023e72a99e5b9ecb8ce2d7407be54c3ea into 37b6683feeb749abdf320fc77de762c7eec2e415

## 🌟 Pull Request Summary
**Related Issues:** https://api.github.com/repos/BLuBin7/shopping-overflow/issues/29
**Commit Messages:**
54da601 Merge 26644c1023e72a99e5b9ecb8ce2d7407be54c3ea into 37b6683feeb749abdf320fc77de762c7eec2e415

## 🔄 Type of change
- [ ] 📚 Documentation, examples, tutorials, dependencies update
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
